### PR TITLE
Level DB: use cache to avoid unecessary S3 requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ deploy:
 
 - Wouter van Lent ([wouter33](https://github.com/wouter33))
 - Josh Strange ([joshstrange](https://github.com/joshstrange); original implementation)
+- Josenivaldo Benito Jr. ([JrBenito](https://github.com/jrbenito))
 
 ## License
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -1,4 +1,5 @@
 var chalk = require('chalk');
+var level = require('level');
 var s3sync = require('s3-sync');
 var readdirp = require('readdirp');
 var cloudfront = require('cloudfront');
@@ -54,12 +55,15 @@ module.exports = function(args) {
     region: args.region
   };
 
+  // Level db for cache, makes less S3 requests
+  db = level('./cache-s3-cf-deploy')
+
   if(args.force_overwrite){
       syncinput.force = true;
   }
 
   return readdirp({root: publicDir, entryType: 'both'})
-      .pipe(s3sync(syncinput).on('data', function(file) {
+      .pipe(s3sync(db, syncinput).on('data', function(file) {
         log.info(file.fullPath + ' -> ' + file.url)
       }).on('end', function() {
         log.info('Deployed to S3, invalidate Cloudfront distribution now');


### PR DESCRIPTION
The use of db for cache might reduce the number of requests necessary to
upload a site to S3. This shall speed up the deployment and maybe reduce
a few cents in the bill of huge sites owners. For small sites the number
of requests does not matter since it shall fall into Amazon free tier.

Signed-off-by: Josenivaldo Benito Jr jrbenito@benito.qsl.br
