### PR TITLE
Switch s3-sync to s3-sync-aws for better compatability

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -1,6 +1,6 @@
 var chalk = require('chalk');
 var level = require('level');
-var s3sync = require('s3-sync');
+var s3sync = require('s3-sync-aws');
 var readdirp = require('readdirp');
 var cloudfront = require('cloudfront');
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
       "email": "woutervanlent@gmail.com"
     },
     {
+      "name": "Josenivaldo Benito Jr."
+      "email": "jrbenito@benito.com.br"
+    },
+    {
       "name": "Josh Strange",
       "email": "josh@joshstrange.com"
     }
@@ -38,7 +42,7 @@
     "chalk": "^1.0.0",
     "level": "^1.4.0",
     "readdirp": "^0.3.3",
-    "s3-sync": "^1.0.1",
+    "s3-sync-aws": "^1.1.0",
     "cloudfront": "^0.3.3"
   },
   "readme": "# hexo-deployer-s3-cloudfront\n\nAmazon S3 and Cloudfront deployer plugin for [Hexo](http://hexo.io/). Based on Josh Strange's orginial plugin.\n\n## Installation\n\n``` bash\n$ npm install hexo-deployer-s3-cloudfront --save\n```\n\n## Usage\n\nAdd the plugin in the plugins list in `_config.yml`:\n\n```plugins:\n- hexo-deployer-s3-cloudfront\n```\n\nand configure the plugin in the same file with:\n\n``` yaml\n# You can use this:\ndeploy:\n  type: s3-cloudfront\n  bucket: <S3 bucket>\n  aws_key: <AWS id key>  // Optional, if the environment variable `AWS_KEY` is set\n  aws_secret: <AWS secret key>  // Optional, if the environment variable `AWS_SECRET` is set\n  concurrency: <number of connections> // Optional\n  region: <region>  // Optional, default: us-standard\n  cf_distribution: <cloudfront distribution> // Which distribution should be invalidated?\n```\n\n## Contributors\n\n- Wouter van Lent ([wouter33](https://github.com/wouter33))\n- Josh Strange ([joshstrange](https://github.com/joshstrange); original implementation)\n\n## License\n\nMIT\n",


### PR DESCRIPTION
s3-sync is not mantained and it uses knox to S3 acess. However knox does
not work for new S3 regions like Frankfurt. The s3-sync-aws is a fork
from original s3-sync and switches from knox to AWS SDK, a better
approach for compatability.

Before fork s3-sync to s3-sync-aws, author offered a pull request to
former, the PR is still active and no forecast to be merged. So this
proposes a switching from s3-sync to s3-sync-aws to address new S3
regions issues and stays aligned with AWS new features.

TODO: check if cloudfront dependency could be dropped in favor of AWS
SDK to manage cloudfront invalidations

Signed-off-by: Josenivaldo Benito Jr jrbenito@benito.qsl.br
