### PR TITLE
Pass headers: make possible to pass custom headers ahead to s3-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ deploy:
   force_overwrite: <true/false> // Optional: If existing files should be forcefully overwritten on S3. Default: true
   region: <region>  // Optional, default: us-standard
   cf_distribution: <cloudfront distribution> // Which distribution should be invalidated?
+  headers: <headers in JSON format> // pass any headers to S3, usefull for metadata cache setting of Hexo assets
+```
+#### Example: header Cache-Control
+
+``` yaml
+deploy:
+  type: s3-cloudfront
+  bucket: my-site-bucket
+  cf_distribution: mydistributionid
+  headers: {CacheControl: 'max-age=604800, public'}
+```
+
+This will set "Cache-Control" header in every file deployed to max-age 1 week. This solves "Leverage browser caching" on most page speed analyzers. For custom metadata use:
+
+``` yaml
+  headers: {Metadata : { x-amz-meta-mykey: "my value" }}
 ```
 
 ## Contributors

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -24,6 +24,10 @@ module.exports = function(args) {
     args.force_overwrite = true;
   }
 
+  if (!args.hasOwnProperty('headers')) {
+    args.headers = {};
+  }
+
   if (!args.bucket || !args.aws_key || !args.aws_secret || !args.cf_distribution) {
     var help = '';
 
@@ -36,8 +40,9 @@ module.exports = function(args) {
     help += '    [aws_secret]: <aws_secret>  # Optional, if provided as environment variable\n';
     help += '    [concurrency]: <concurrency>\n';
     help += '    [force_overwrite]: <true/false>   # Optional, default true\n';
-    help += '    [region]: <region>          # Optional, default "us-standard"\n',
-    help += '    [cf_distribution]: <cf_distribution>\n\n';
+    help += '    [region]: <region>          # Optional, default "us-standard"\n';
+    help += '    [cf_distribution]: <cf_distribution>\n';
+    help += '    [headers]: <headers in json format>\n\n';
     help += 'For more help, you can check the docs: ' + chalk.underline('https://github.com/Wouter33/hexo-deployer-s3-cloudfront');
 
     console.log(help);
@@ -52,7 +57,8 @@ module.exports = function(args) {
     secret: args.aws_secret,
     bucket: args.bucket,
     concurrency: args.concurrency,
-    region: args.region
+    region: args.region,
+    headers: args.headers
   };
 
   // Level db for cache, makes less S3 requests


### PR DESCRIPTION
S3-sync has the ability to set custom headers to be passed to objects
and saved as metadata. S3-sync itself use this ability to save a md5sum
hash of each object in a custom meta header.

This patch includes ability to hexo-deployer-s3-cloudfront to pass
custom headers (for all objects at once) to s3-sync save them as headers
and metadata. Main inspiration is to be able to pass CacheControl and
set Cache-Control header to objects since this avoids "Leverage Browse
Caching" warnings in most page speed tests. However, any metadata can be
passed to objects as examples provided shows.

Signed-off-by: Josenivaldo Benito Jr jrbenito@benito.qsl.br
