### PR TITLE
Adding option to add prefix S3 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ deploy:
   concurrency: <number of connections> // Optional
   force_overwrite: <true/false> // Optional: If existing files should be forcefully overwritten on S3. Default: true
   region: <region>  // Optional, default: us-standard
+  prefix: <cloudfront distribution> // Optional: S3 key prefix ending in /
   cf_distribution: <cloudfront distribution> // Optional: Which distribution should be invalidated?
   headers: <headers in JSON format> // pass any headers to S3, usefull for metadata cache setting of Hexo assets
 ```

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -28,6 +28,10 @@ module.exports = function(args) {
     args.headers = {};
   }
 
+  if (!args.hasOwnProperty('prefix')) {
+    args.prefix = false;
+  }
+
   if (!args.bucket || !args.aws_key || !args.aws_secret) {
     var help = '';
 
@@ -41,7 +45,8 @@ module.exports = function(args) {
     help += '    [concurrency]: <concurrency> # Optional\n';
     help += '    [force_overwrite]: <true/false>   # Optional, default true\n';
     help += '    [region]: <region>          # Optional, default "us-standard"\n';
-    help += '    [cf_distribution]: <cf_distribution> # Optional,\n';
+    help += '    [prefix]: <S3 key prefix ending in /> # Optional\n';
+    help += '    [cf_distribution]: <cf_distribution> # Optional\n';
     help += '    [headers]: <headers in json format> # Optional\n\n';
     help += 'For more help, you can check the docs: ' + chalk.underline('https://github.com/Wouter33/hexo-deployer-s3-cloudfront');
 
@@ -67,6 +72,9 @@ module.exports = function(args) {
   if(args.force_overwrite){
       syncinput.force = true;
   }
+  if(args.prefix){
+      syncinput.prefix = args.prefix;
+  }
 
   return readdirp({root: publicDir, entryType: 'both'})
       .pipe(s3sync(db, syncinput).on('data', function(file) {
@@ -80,7 +88,9 @@ module.exports = function(args) {
 
             var cf = cloudfront.createClient(args.aws_key, args.aws_secret);
 
-            return cf.createInvalidation(args.cf_distribution, 'dsadasds' + Math.round(new Date().getTime()/1000), '/*', function(err, invalidation) {
+            var cfPath = '/' + args.prefix + '*' || '/*';
+
+            return cf.createInvalidation(args.cf_distribution, 'dsadasds' + Math.round(new Date().getTime()/1000), cfPath, function(err, invalidation) {
                 if (err){
                     console.log(err);
                 } else {


### PR DESCRIPTION
My blog does not reside in the root of the S3 bucket / CloudFront distribution, as I am making use of the "root:" setting in _config.yml.

Adding the optional prefix allows the remote deployment to match the local structure.